### PR TITLE
cleverref is in the wrong place

### DIFF
--- a/paper/project-name.tex
+++ b/paper/project-name.tex
@@ -16,7 +16,6 @@
 \usepackage{booktabs}  %% tables
 \usepackage{comment}
 \usepackage{enumitem}
-\usepackage[capitalize,noabbrev]{cleveref}
 
 %% LINE NUMBERS
 
@@ -120,7 +119,11 @@
 %% PDF SETUP
 
 \hypersetup{colorlinks=true,citecolor=darkgray,linkcolor=darkgray}
-                    
+
+%% References 
+\usepackage[capitalize,noabbrev]{cleveref}
+
+
 %% OPENING
 
 \title{A well-written paper about interesting stuff}


### PR DESCRIPTION
## What's the problem?
The title says it all. More particularly: attempting to use ```pdflatex project-name.tex``` on the current version results in this error:
```
! Package cleveref Error: cleveref must be loaded after amsmath!.
```

## What does this PR do?
This PR simply moves the cleverref ```\usepackage``` command to after the inclusion of ```amsmath```. I've defined a comment block for this, but you may wish to have it elsewhere.